### PR TITLE
Feat/extranet location association

### DIFF
--- a/plugins/modules/zia_location_management.py
+++ b/plugins/modules/zia_location_management.py
@@ -303,6 +303,49 @@ options:
           - "Note: If you want Zscaler to provision static IP addresses for your organization, contact Zscaler Support."
         type: str
         required: false
+  extranet:
+    description:
+      - "The ID of the extranet resource that must be assigned to the location."
+      - "Extranets are configured as part of Zscaler Extranet Application Support."
+    type: dict
+    required: false
+    suboptions:
+      id:
+        description: "The unique identifier for the extranet."
+        type: int
+        required: true
+  extranet_dns:
+    description:
+      - "The ID of the DNS server configuration used in the extranet."
+      - "References a DNS entry from the extranet's extranet_dns_list."
+    type: dict
+    required: false
+    suboptions:
+      id:
+        description: "The ID of the DNS server configuration from the extranet."
+        type: int
+        required: true
+  extranet_ip_pool:
+    description:
+      - "The ID of the traffic selector specified in the extranet."
+      - "References an IP pool entry from the extranet's extranet_ip_pool_list."
+    type: dict
+    required: false
+    suboptions:
+      id:
+        description: "The ID of the traffic selector (IP pool) from the extranet."
+        type: int
+        required: true
+  default_extranet_dns:
+    description:
+      - "Indicates that the DNS server configuration used in the extranet is the designated default DNS server."
+    type: bool
+    required: false
+  default_extranet_ts_pool:
+    description:
+      - "Indicates that the traffic selector specified in the extranet is the designated default traffic selector."
+    type: bool
+    required: false
 """
 
 EXAMPLES = r"""
@@ -380,6 +423,46 @@ EXAMPLES = r"""
     sub_loc_scope_values:
       - "vpc-12345678"
       - "vpc-87654321"
+
+# Full extranet dependency chain: VPN credential -> Extranet -> Location association
+- name: Create UFQDN VPN credential
+  zscaler.ziacloud.zia_traffic_forwarding_vpn_credentials:
+    type: "UFQDN"
+    fqdn: "branch1-extranet@acme.com"
+    comments: "Extranet VPN credential"
+    pre_shared_key: "{{ extranet_psk }}"
+  register: vpn_cred
+
+- name: Create extranet with DNS and traffic selectors
+  zscaler.ziacloud.zia_extranet:
+    name: "Partner Extranet"
+    description: "Extranet for partner branch"
+    extranet_dns_list:
+      - name: "Primary DNS"
+        primary_dns_server: "8.8.8.8"
+        secondary_dns_server: "4.4.2.2"
+        use_as_default: true
+    extranet_ip_pool_list:
+      - name: "Traffic Selector 1"
+        ip_start: "10.0.0.1"
+        ip_end: "10.0.0.100"
+        use_as_default: true
+  register: extranet
+
+- name: Create location with extranet association
+  zscaler.ziacloud.zia_location_management:
+    name: "Branch1_Extranet_Location"
+    description: "Location for extranet branch"
+    country: "UNITED_STATES"
+    tz: "UNITED_STATES_AMERICA_LOS_ANGELES"
+    auth_required: true
+    vpn_credentials:
+      - id: "{{ vpn_cred.data.id }}"
+        type: "{{ vpn_cred.data.type }}"
+    extranet:
+      id: "{{ extranet.data.id }}"
+    default_extranet_dns: true
+    default_extranet_ts_pool: true
 """
 
 RETURN = """
@@ -401,9 +484,20 @@ from ansible_collections.zscaler.ziacloud.plugins.module_utils.zia_client import
 import json
 
 
+def normalize_extranet_ref(ref):
+    """Normalize an extranet/ip_pool/dns reference dict to only include id."""
+    if not ref or not isinstance(ref, dict):
+        return None
+    rid = ref.get("id")
+    if rid is not None:
+        return {"id": rid}
+    return None
+
+
 def normalize_location(location):
     """
     Normalize location data by removing computed values.
+    Preserves extranet-related fields so they can be managed.
     """
     if not location:
         return {}
@@ -414,16 +508,11 @@ def normalize_location(location):
         "comments",
         "child_count",
         "cookies_and_proxy",
-        "default_extranet_dns",
-        "default_extranet_ts_pool",
         "digest_auth_enabled",
         "dynamiclocation_groups",
         "ec_location",
         "exclude_from_dynamic_groups",
         "exclude_from_manual_groups",
-        "extranet",
-        "extranet_dns",
-        "extranet_ip_pool",
         "kerberos_auth",
         "language",
         "match_in_child",
@@ -432,6 +521,11 @@ def normalize_location(location):
     ]
     for attr in computed_values:
         normalized.pop(attr, None)
+
+    for ref_key in ("extranet", "extranet_dns", "extranet_ip_pool"):
+        val = normalized.get(ref_key)
+        if val and isinstance(val, dict):
+            normalized[ref_key] = normalize_extranet_ref(val)
     return normalized
 
 
@@ -500,12 +594,21 @@ def core(module):
         "iot_discovery_enabled",
         "iot_enforce_policy_set",
         "vpn_credentials",
+        "extranet",
+        "extranet_dns",
+        "extranet_ip_pool",
+        "default_extranet_dns",
+        "default_extranet_ts_pool",
     ]
 
     location_mgmt = {param: module.params.get(param) for param in params}
 
     # Normalize the VPN creds from user input
     location_mgmt["vpn_credentials"] = normalize_vpn_credentials(module.params.get("vpn_credentials", []))
+    # Normalize extranet reference dicts
+    for ref_key in ("extranet", "extranet_dns", "extranet_ip_pool"):
+        val = module.params.get(ref_key)
+        location_mgmt[ref_key] = normalize_extranet_ref(val) if val else None
 
     validate_location_mgmt(location_mgmt)
 
@@ -628,6 +731,11 @@ def core(module):
                         "iot_discovery_enabled": desired_location.get("iot_discovery_enabled"),
                         "iot_enforce_policy_set": desired_location.get("iot_enforce_policy_set"),
                         "vpn_credentials": desired_location.get("vpn_credentials"),
+                        "extranet": desired_location.get("extranet"),
+                        "extranet_dns": desired_location.get("extranet_dns"),
+                        "extranet_ip_pool": desired_location.get("extranet_ip_pool"),
+                        "default_extranet_dns": desired_location.get("default_extranet_dns"),
+                        "default_extranet_ts_pool": desired_location.get("default_extranet_ts_pool"),
                     }
                 )
                 module.warn("Payload Update for SDK: {}".format(update_location))
@@ -680,6 +788,11 @@ def core(module):
                     "iot_discovery_enabled": desired_location.get("iot_discovery_enabled"),
                     "iot_enforce_policy_set": desired_location.get("iot_enforce_policy_set"),
                     "vpn_credentials": desired_location.get("vpn_credentials"),
+                    "extranet": desired_location.get("extranet"),
+                    "extranet_dns": desired_location.get("extranet_dns"),
+                    "extranet_ip_pool": desired_location.get("extranet_ip_pool"),
+                    "default_extranet_dns": desired_location.get("default_extranet_dns"),
+                    "default_extranet_ts_pool": desired_location.get("default_extranet_ts_pool"),
                 }
             )
             module.warn("Payload Update for SDK: {}".format(create_location))
@@ -763,6 +876,29 @@ def main():
             ),
             required=False,
         ),
+        extranet=dict(
+            type="dict",
+            options=dict(
+                id=dict(type="int", required=True),
+            ),
+            required=False,
+        ),
+        extranet_dns=dict(
+            type="dict",
+            options=dict(
+                id=dict(type="int", required=True),
+            ),
+            required=False,
+        ),
+        extranet_ip_pool=dict(
+            type="dict",
+            options=dict(
+                id=dict(type="int", required=True),
+            ),
+            required=False,
+        ),
+        default_extranet_dns=dict(type="bool", required=False),
+        default_extranet_ts_pool=dict(type="bool", required=False),
         state=dict(type="str", choices=["present", "absent"], default="present"),
     )
     module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)

--- a/plugins/modules/zia_location_management_info.py
+++ b/plugins/modules/zia_location_management_info.py
@@ -259,6 +259,55 @@ locations:
       returned: always
       type: bool
       sample: true
+    extranet:
+      description: The extranet resource assigned to the location.
+      returned: when available
+      type: dict
+      contains:
+        id:
+          description: The unique identifier for the extranet.
+          type: int
+          sample: 12345678
+        name:
+          description: The name of the extranet.
+          type: str
+          sample: "Partner Extranet"
+    extranet_dns:
+      description: The DNS server configuration from the extranet assigned to the location.
+      returned: when available
+      type: dict
+      contains:
+        id:
+          description: The ID of the DNS server configuration in the extranet.
+          type: int
+          sample: 87654321
+        name:
+          description: The name of the DNS server configuration.
+          type: str
+          sample: "Primary DNS"
+    extranet_ip_pool:
+      description: The traffic selector (IP pool) from the extranet assigned to the location.
+      returned: when available
+      type: dict
+      contains:
+        id:
+          description: The ID of the traffic selector in the extranet.
+          type: int
+          sample: 11223344
+        name:
+          description: The name of the traffic selector.
+          type: str
+          sample: "Traffic Selector 1"
+    default_extranet_dns:
+      description: Indicates that the DNS server configuration from the extranet is the designated default DNS server.
+      returned: when available
+      type: bool
+      sample: true
+    default_extranet_ts_pool:
+      description: Indicates that the traffic selector from the extranet is the designated default traffic selector.
+      returned: when available
+      type: bool
+      sample: true
 """
 
 

--- a/tests/unit/plugins/modules/test_zia_location_management.py
+++ b/tests/unit/plugins/modules/test_zia_location_management.py
@@ -90,3 +90,82 @@ class TestLocationManagementModule(ModuleTestCase):
 
         with pytest.raises(AnsibleFailJson):
             zia_location_management.main()
+
+    def test_create_with_extranet(self, mock_client):
+        mock_client.locations.list_locations.return_value = ([], None, None)
+        mock_client.locations.add_location.return_value = (
+            MockBox({
+                "id": 1,
+                "name": "extranet-location",
+                "extranet": {"id": 100, "name": "Partner Extranet"},
+                "extranet_dns": {"id": 200, "name": "Primary DNS"},
+                "extranet_ip_pool": {"id": 300, "name": "TS1"},
+                "default_extranet_dns": True,
+                "default_extranet_ts_pool": False,
+            }),
+            None,
+            None,
+        )
+        set_module_args(
+            provider=DEFAULT_PROVIDER,
+            name="extranet-location",
+            state="present",
+            extranet={"id": 100},
+            extranet_dns={"id": 200},
+            extranet_ip_pool={"id": 300},
+            default_extranet_dns=True,
+            default_extranet_ts_pool=False,
+        )
+        from ansible_collections.zscaler.ziacloud.plugins.modules import zia_location_management
+
+        with pytest.raises(AnsibleExitJson) as result:
+            zia_location_management.main()
+        assert result.value.result.get("changed") is True
+        data = result.value.result.get("data", {})
+        assert data.get("extranet", {}).get("id") == 100
+        assert data.get("default_extranet_dns") is True
+
+    def test_update_with_extranet(self, mock_client):
+        existing = MockBox({
+            "id": 1,
+            "name": "extranet-location",
+            "extranet": None,
+            "extranet_dns": None,
+            "extranet_ip_pool": None,
+            "default_extranet_dns": False,
+            "default_extranet_ts_pool": False,
+        })
+        mock_client.locations.get_location.return_value = (existing, None, None)
+        mock_client.locations.update_location.return_value = (
+            MockBox({
+                "id": 1,
+                "name": "extranet-location",
+                "extranet": {"id": 100, "name": "Partner Extranet"},
+                "extranet_dns": {"id": 200, "name": "Primary DNS"},
+                "extranet_ip_pool": {"id": 300, "name": "TS1"},
+                "default_extranet_dns": True,
+                "default_extranet_ts_pool": True,
+            }),
+            None,
+            None,
+        )
+        set_module_args(
+            provider=DEFAULT_PROVIDER,
+            id=1,
+            name="extranet-location",
+            state="present",
+            extranet={"id": 100},
+            extranet_dns={"id": 200},
+            extranet_ip_pool={"id": 300},
+            default_extranet_dns=True,
+            default_extranet_ts_pool=True,
+        )
+        from ansible_collections.zscaler.ziacloud.plugins.modules import zia_location_management
+
+        with pytest.raises(AnsibleExitJson) as result:
+            zia_location_management.main()
+        assert result.value.result.get("changed") is True
+        data = result.value.result.get("data", {})
+        assert data.get("extranet", {}).get("id") == 100
+        assert data.get("default_extranet_dns") is True
+        assert data.get("default_extranet_ts_pool") is True

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,3 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

Adds extranet association support to `zia_location_management`. This is the last piece—you can now wire VPN credentials → extranet → location in one go.

### Changes

**`plugins/modules/zia_location_management.py`** (+146 / -5)
- 5 new parameters (DOCUMENTATION + argument_spec): `extranet` (dict), `extranet_dns` (dict), `extranet_ip_pool` (dict), `default_extranet_dns` (bool), `default_extranet_ts_pool` (bool)
- New `normalize_extranet_ref()` helper normalizes ref dicts to `{id: N}` for idempotency comparison
- `normalize_location()` stopped stripping extranet fields—they are manageable now
- Update and create payloads include all 5 fields
- Examples show the full dependency chain

**`plugins/modules/zia_location_management_info.py`** (+49)
- RETURN docs for all 5 extranet output fields

**`tests/unit/plugins/modules/test_zia_location_management.py`** (+79)
- Test: create location with extranet, DNS, IP pool, default flags
- Test: add extranet association to an existing location

### Usage order

1. VPN credentials — `zia_traffic_forwarding_vpn_credentials`
2. Extranet (DNS + IP pools) — `zia_extranet`
3. Location (extranet association) — `zia_location_management`

### Verification

- `532 passed, 3 failed` — same pre-existing failures, unrelated
- No secrets in the diff
- No test regressions