### PR TITLE
fix: stabilize sanity workflows and meet RedHat AAP requirements

### DIFF
--- a/.github/workflows/ansible-test-sanity.yml
+++ b/.github/workflows/ansible-test-sanity.yml
@@ -29,6 +29,10 @@ jobs:
         include:
           - ansible: "2.16"
             python_ver: "3.11"
+          # RedHat AAP requires the minimum supported ansible-core (2.16)
+          # to be verified against Python 3.12.
+          - ansible: "2.16"
+            python_ver: "3.12"
           - ansible: "2.17"
             python_ver: "3.11"
           - ansible: "2.18"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,10 @@ jobs:
         include:
           - ansible: "2.16"
             python_ver: "3.11"
+          # RedHat AAP requires the minimum supported ansible-core (2.16)
+          # to be verified against Python 3.12.
+          - ansible: "2.16"
+            python_ver: "3.12"
           - ansible: "2.17"
             python_ver: "3.11"
           - ansible: "2.18"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Zscaler Internet Access (ZIA) Ansible Collection Changelog
 
+## v2.2.1 (June 1, 2026)
+
+### Notes
+
+- Python Versions: **v3.9, v3.10, v3.11**
+
+#### Internals
+
+[#121](https://github.com/zscaler/ziacloud-ansible/pull/121) - Fixed sanity CI so the matrix-pinned `ansible-core` is installed after `poetry install` (preventing an unintended upgrade that broke `validate-modules`), bumped `requires_ansible` to `>=2.16.0`, added a `2.16`/Python 3.12 sanity job, and corrected README license badge and relative links
+
 ## v2.2.0 (May 29, 2026)
 
 ### Notes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,29 @@ For every module you add or change:
 3. **Lint/format**: `make format` (black) and `make check-format` must pass.
    The full unit suite runs via `poetry run pytest tests/unit/`.
 
+## CI / Sanity requirements
+
+- `meta/runtime.yml` **MUST** declare `requires_ansible: ">=2.16.0"` (RedHat AAP
+  minimum). Keep the CI matrix aligned: test `ansible-core` 2.16+ and verify the
+  minimum version (2.16) against **Python 3.12**.
+- For **every** Ansible version in the CI matrix there **MUST** be a matching
+  `tests/sanity/ignore-2.XX.txt`. Adding a new matrix row (e.g. `2.20`) without
+  the corresponding ignore file makes `validate-modules` fail every module with
+  `missing-gplv3-license`.
+- In the sanity/release workflows, install the matrix-pinned `ansible-core`
+  **after** `poetry install`, with
+  `poetry run pip install --force-reinstall --no-deps "<stable-tarball>"`.
+  Because `pyproject.toml` pins `ansible-core = "*"`, running `poetry install`
+  after the pin would upgrade ansible-core to the newest release (e.g. 2.21 on
+  Python 3.12) and break sanity.
+- Run sanity the way RedHat recommends before submitting:
+  `ansible-test sanity --docker default --python 3.12`. The `WARNING: ... virtual
+  environments are out-of-date ...` line is benign (cached venvs rebuild); only
+  `ERROR:`/`FATAL:` lines or a non-zero exit indicate a real failure.
+- README links **MUST** be absolute GitHub URLs (Automation Hub does not resolve
+  relative paths); the license badge must point to
+  `https://github.com/zscaler/ziacloud-ansible/blob/master/LICENSE`.
+
 ## Commands
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Ansible Lint](https://github.com/zscaler/ziacloud-ansible/actions/workflows/ansible-test-lint.yml/badge.svg?branch=master)](https://github.com/zscaler/ziacloud-ansible/actions/workflows/ansible-test-lint.yml)
 [![sanity](https://github.com/zscaler/ziacloud-ansible/actions/workflows/ansible-test-sanity.yml/badge.svg?branch=master)](https://github.com/zscaler/ziacloud-ansible/actions/workflows/ansible-test-sanity.yml)
 [![Documentation Status](https://readthedocs.org/projects/ziacloud-ansible/badge/?version=latest)](https://ziacloud-ansible.readthedocs.io/en/latest/?badge=latest)
-[![License](https://img.shields.io/github/license/zscaler/ziacloud-ansible?color=blue)](https://github.com/zscaler/ziacloud-ansible/v2/blob/master/LICENSE)
+[![License](https://img.shields.io/github/license/zscaler/ziacloud-ansible?color=blue)](https://github.com/zscaler/ziacloud-ansible/blob/master/LICENSE)
 [![Zscaler Community](https://img.shields.io/badge/zscaler-community-blue)](https://community.zscaler.com/)
 
 ## Zscaler Support
@@ -277,13 +277,13 @@ poetry run pytest tests/unit/ --cov=plugins --cov-branch --cov-report=xml:covera
 poetry run python scripts/check_coverage.py --line-min 70 --branch-min 48
 ```
 
-This produces `coverage.xml` and `htmlcov/` (open `htmlcov/index.html` for the report). See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
+This produces `coverage.xml` and `htmlcov/` (open `htmlcov/index.html` for the report). See [CONTRIBUTING.md](https://github.com/zscaler/ziacloud-ansible/blob/master/CONTRIBUTING.md) for details.
 
 ## Releasing, changelogs, versioning and deprecation
 
 The intended release frequency for major and minor versions are performed whenever there is a need for fixing issues or to address security concerns.
 
-Changelog details are created automatically and more recently can be found [here](./CHANGELOG.md), but also the full history is [here](https://github.com/zscaler/ziacloud-ansible/releases).
+Changelog details are created automatically and more recently can be found [here](https://github.com/zscaler/ziacloud-ansible/blob/master/CHANGELOG.md), but also the full history is [here](https://github.com/zscaler/ziacloud-ansible/releases).
 
 [Semantic versioning](https://semver.org/) is adhered to for this project.
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,6 +9,20 @@ Releases
 Zscaler Internet Access (ZIA) Ansible Collection Changelog
 ----------------------------------------------------------
 
+Version 2.2.1
+==============
+
+v2.2.1 (June 1, 2026)
+---------------------------
+
+### Notes
+
+- Python Versions: **v3.9, v3.10, v3.11**
+
+#### Internals
+
+* (`#121 <https://github.com/zscaler/ziacloud-ansible/pull/121>`_) - Fixed sanity CI so the matrix-pinned `ansible-core` is installed after `poetry install` (preventing an unintended upgrade that broke `validate-modules`), bumped `requires_ansible` to `>=2.16.0`, added a `2.16`/Python 3.12 sanity job, and corrected README license badge and relative links
+
 Version 2.2.0
 ==============
 

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.15.0"
+requires_ansible: ">=2.16.0"


### PR DESCRIPTION
- Install matrix-pinned ansible-core after Installing dependencies from lock file

No dependencies to install or update (--force-reinstall --no-deps) so sanity runs as the labeled version instead of being upgraded to 2.21 on py3.12, which broke validate-modules (missing-gplv3-license)
- Bump requires_ansible to >=2.16.0 and add a 2.16/Python 3.12 sanity job
- zpacloud: add tests/sanity/ignore-2.20.txt; fix pep8 E501 in zpa_client.py
- Move release docs job off unsupported Python 3.9 -> 3.11
- Fix README license badge 404 (/v2/ path) and convert relative CONTRIBUTING.md / CHANGELOG.md links to absolute GitHub URLs
- Update CHANGELOG, release_notes.rst, and CLAUDE.md (ziacloud #121, zpacloud #95)

# Contributing

At this time we are not accepting contributions, but we welcome suggestions on how to improve this Collection and feature requests, which can then be added in future releases. These suggestions must be submitted via support ticket using Zscaler support.

~> **NOTE** Pull Requests submitted via this repository will not be responded.

## Zscaler Support

-> **Disclaimer:** Please refer to our [General Support Statement](https://zscaler.github.io/zpacloud-ansible/support.html) before proceeding with the use of this collection. You can also refer to our [troubleshooting guide](https://zscaler.github.io/zpacloud-ansible/troubleshooting.html) for guidance on typical problems.
