### PR TITLE
fix: add Red Hat partner certification checker and resolve review findings

### DIFF
--- a/.github/workflows/certification.yml
+++ b/.github/workflows/certification.yml
@@ -1,0 +1,42 @@
+---
+# This workflow calls a pinned version of the
+# reusable workflow. Copy this file into your
+# repository to check against pinned versions
+# of Automation Hub tests.
+# The version is pinned to an exact release tag
+# (e.g. @v2.0.0) for supply chain security.
+# Use Dependabot to receive automatic PRs when
+# new versions are released.
+name: Run collection certification checks
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * *"
+
+concurrency:
+  group: cert-ver-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+# Files that are not related to the core functionality
+# of your collection can cause Ansible Lint to fail.
+# If this happens, add an .ansible-lint file that includes
+# those files and directories to the root of your
+# repository; for example:
+# https://github.com/ansible-collections/partner-certification-checker/blob/main/.ansible-lint
+
+# If there are sanity test failures that cannot be fixed and are allowed to ignore
+# https://docs.ansible.com/projects/lint/rules/sanity/, create a sanity ignore file
+# https://docs.ansible.com/projects/ansible/devel/dev_guide/testing/sanity/ignores.html#ignore-file-location
+# for each affected version of ansible-core (for example, `tests/sanity/ignore-2.18.txt`) and add corresponding entries.
+jobs:
+  call:
+    uses: ansible-collections/partner-certification-checker/.github/workflows/certification-reusable.yml@v2.0.0 # zizmor: ignore[unpinned-uses]
+    # This collection requires a minimum of ansible-core 2.16.0
+    # (meta/runtime.yml: requires_ansible ">=2.16.0"), which is the
+    # reusable workflow default, so no overrides are needed.

--- a/.github/workflows/check_requirements.yml
+++ b/.github/workflows/check_requirements.yml
@@ -34,7 +34,7 @@ jobs:
           python-version: ${{ inputs.python-version }}
 
       - name: Install Poetry
-        uses: Gr1N/setup-poetry@v8
+        uses: Gr1N/setup-poetry@v9
         with:
           poetry-version: "1.8.5"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,7 +164,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Store built collection
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: collection
           path: |
@@ -227,7 +227,7 @@ jobs:
           mkdir -p ziacloud-ansible/ansible_collections/zscaler/ziacloud
 
       - name: Deploy to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@v4.6.3
+        uses: JamesIves/github-pages-deploy-action@v4.8.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: gh-pages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 #### Internals
 
 [#123](https://github.com/zscaler/ziacloud-ansible/pull/123) - Fixed sanity CI so the matrix-pinned `ansible-core` is installed after `poetry install` (preventing an unintended upgrade that broke `validate-modules`), bumped `requires_ansible` to `>=2.16.0`, added a `2.16`/Python 3.12 sanity job, and corrected README license badge and relative links
+[#123](https://github.com/zscaler/ziacloud-ansible/pull/123) - Added the Red Hat partner certification checker workflow, set `license: [MIT]` in `galaxy.yml`, and resolved README link and version-statement issues raised during certification review
 
 ## v2.2.2 (June 1, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 #### Internals
 
 [#123](https://github.com/zscaler/ziacloud-ansible/pull/123) - Fixed sanity CI so the matrix-pinned `ansible-core` is installed after `poetry install` (preventing an unintended upgrade that broke `validate-modules`), bumped `requires_ansible` to `>=2.16.0`, added a `2.16`/Python 3.12 sanity job, and corrected README license badge and relative links
-[#123](https://github.com/zscaler/ziacloud-ansible/pull/123) - Added the Red Hat partner certification checker workflow, set `license: [MIT]` in `galaxy.yml`, and resolved README link and version-statement issues raised during certification review
+[#127](https://github.com/zscaler/ziacloud-ansible/pull/127) - Added the Red Hat partner certification checker workflow, set `license: [MIT]` in `galaxy.yml`, and resolved README link and version-statement issues raised during certification review
 
 ## v2.2.2 (June 1, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Zscaler Internet Access (ZIA) Ansible Collection Changelog
 
+## v2.2.4 (June 2, 2026)
+
+### Notes
+
+- Python Versions: **v3.9, v3.10, v3.11**
+
+#### Internals
+
+[#127](https://github.com/zscaler/ziacloud-ansible/pull/127) - Added the Red Hat partner certification checker workflow, set `license: [MIT]` in `galaxy.yml`, and resolved README link and version-statement issues raised during certification review
+
 ## v2.2.3 (June 1, 2026)
 
 ### Notes
@@ -9,7 +19,6 @@
 #### Internals
 
 [#123](https://github.com/zscaler/ziacloud-ansible/pull/123) - Fixed sanity CI so the matrix-pinned `ansible-core` is installed after `poetry install` (preventing an unintended upgrade that broke `validate-modules`), bumped `requires_ansible` to `>=2.16.0`, added a `2.16`/Python 3.12 sanity job, and corrected README license badge and relative links
-[#127](https://github.com/zscaler/ziacloud-ansible/pull/127) - Added the Red Hat partner certification checker workflow, set `license: [MIT]` in `galaxy.yml`, and resolved README link and version-statement issues raised during certification review
 
 ## v2.2.2 (June 1, 2026)
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -24,7 +24,7 @@ Notes
 
 * (`#123 <https://github.com/zscaler/ziacloud-ansible/pull/123>`_) - Fixed sanity CI so the matrix-pinned `ansible-core` is installed after `poetry install` (preventing an unintended upgrade that broke `validate-modules`), bumped `requires_ansible` to `>=2.16.0`, added a `2.16`/Python 3.12 sanity job, and corrected README license badge and relative links
 
-* (`#123 <https://github.com/zscaler/ziacloud-ansible/pull/123>`_) - Added the Red Hat partner certification checker workflow, set `license: [MIT]` in `galaxy.yml`, and resolved README link and version-statement issues raised during certification review
+* (`#127 <https://github.com/zscaler/ziacloud-ansible/pull/127>`_) - Added the Red Hat partner certification checker workflow, set `license: [MIT]` in `galaxy.yml`, and resolved README link and version-statement issues raised during certification review
 
 * (`#123 <https://github.com/zscaler/ziacloud-ansible/pull/123>`_) - Release v2.2.3
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -24,6 +24,8 @@ Notes
 
 * (`#123 <https://github.com/zscaler/ziacloud-ansible/pull/123>`_) - Fixed sanity CI so the matrix-pinned `ansible-core` is installed after `poetry install` (preventing an unintended upgrade that broke `validate-modules`), bumped `requires_ansible` to `>=2.16.0`, added a `2.16`/Python 3.12 sanity job, and corrected README license badge and relative links
 
+* (`#123 <https://github.com/zscaler/ziacloud-ansible/pull/123>`_) - Added the Red Hat partner certification checker workflow, set `license: [MIT]` in `galaxy.yml`, and resolved README link and version-statement issues raised during certification review
+
 * (`#123 <https://github.com/zscaler/ziacloud-ansible/pull/123>`_) - Release v2.2.3
 
 Version 2.2.2

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,6 +9,21 @@ Releases
 Zscaler Internet Access (ZIA) Ansible Collection Changelog
 ----------------------------------------------------------
 
+Version 2.2.4
+==============
+
+v2.2.4 (June 2, 2026)
+---------------------------
+
+Notes
+-------
+
+- Python Versions: **v3.9, v3.10, v3.11**
+
+#### Internals
+
+* (`#127 <https://github.com/zscaler/ziacloud-ansible/pull/127>`_) - Added the Red Hat partner certification checker workflow, set `license: [MIT]` in `galaxy.yml`, and resolved README link and version-statement issues raised during certification review
+
 Version 2.2.3
 ==============
 
@@ -23,8 +38,6 @@ Notes
 #### Internals
 
 * (`#123 <https://github.com/zscaler/ziacloud-ansible/pull/123>`_) - Fixed sanity CI so the matrix-pinned `ansible-core` is installed after `poetry install` (preventing an unintended upgrade that broke `validate-modules`), bumped `requires_ansible` to `>=2.16.0`, added a `2.16`/Python 3.12 sanity job, and corrected README license badge and relative links
-
-* (`#127 <https://github.com/zscaler/ziacloud-ansible/pull/127>`_) - Added the Red Hat partner certification checker workflow, set `license: [MIT]` in `galaxy.yml`, and resolved README link and version-statement issues raised during certification review
 
 * (`#123 <https://github.com/zscaler/ziacloud-ansible/pull/123>`_) - Release v2.2.3
 


### PR DESCRIPTION
## Summary

Second round of Red Hat certification work, addressing the latest Partner Engineering review and adopting the recommended pre-submission tooling.

- Added the official Red Hat partner certification checker workflow (`.github/workflows/certification.yml`), pinning the reusable workflow to `@v2.0.0`. It runs the same pinned sanity + ansible-lint (production profile) checks that Automation Hub uses on import, on PRs, manual dispatch, and a daily schedule.
- Verified locally: `ansible-lint --profile production` passes with 0 warnings/errors, and `galaxy-importer` completes successfully on the built tarball.
- Updated `CHANGELOG.md` and `docs/source/release_notes.rst`.

## Test plan

- [x] `ansible-lint --profile production` passes (0 failures/0 warnings)
- [x] `galaxy-importer` processing completed successfully
- [x] `ansible-galaxy collection build` succeeds
- [x] `.ansible-lint` excludes `.github/`; certification workflow YAML validates

Made with [Cursor](https://cursor.com)